### PR TITLE
Stop resetting the Blaze evaluation context

### DIFF
--- a/implementations/blaze/main.cc
+++ b/implementations/blaze/main.cc
@@ -15,7 +15,6 @@
 
 bool validate_all(auto &context, const auto &instances, const auto &schema_template) {
   for (std::size_t num = 0; num < instances.size(); num++) {
-    context.reset();
     const auto result{
         sourcemeta::blaze::evaluate(schema_template, instances[num], context)};
     if (!result) {


### PR DESCRIPTION
It is no longer needed

Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
