### PR TITLE
Updated Corvus implementation to 9.0 SDK and release build.

### DIFF
--- a/implementations/corvus/Dockerfile
+++ b/implementations/corvus/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:8.0
+FROM mcr.microsoft.com/dotnet/sdk:9.0
 
 COPY . /app
 RUN dotnet tool install --global Corvus.Json.JsonSchema.TypeGeneratorTool --prerelease

--- a/implementations/corvus/bench.csproj
+++ b/implementations/corvus/bench.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Corvus.Json.ExtendedTypes" Version="4.0.0-preview.30" />
+    <PackageReference Include="Corvus.Json.ExtendedTypes" Version="4.0.12" />
   </ItemGroup>
 
 </Project>

--- a/implementations/corvus/generate-and-run.sh
+++ b/implementations/corvus/generate-and-run.sh
@@ -25,6 +25,6 @@ COMPILE_TIME=$(expr $END_TIME - $START_TIME)
 # Remove temporary generated files
 find . -type f -name '*.cs' -not -name 'Program.cs' -delete
 
-RUNTIME=$(/app/bin/Release/net8.0/bench "$INSTANCES" | tr -d '\n')
+RUNTIME=$(/app/bin/Release/net9.0/bench "$INSTANCES" | tr -d '\n')
 echo $RUNTIME,$COMPILE_TIME
 exit $?


### PR DESCRIPTION
This uses the MS 9.0 SDK base container image, compiles to the 9.0 runtime, and uses the release version 4.0.12 of Corvus.JsonSchema