### PR TITLE
Remove the "format" keyword from schemas before running

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,8 +47,12 @@ jobs:
         id: cache-report
         with:
           path: dist/report.csv
-          key: ${{ matrix.impl }}-${{ hashFiles(format('implementations/{0}/**/*', matrix.impl), 'schemas/**/*', 'report.sh') }}-${{ inputs.runs || 3 }}
+          key: noformat-${{ matrix.impl }}-${{ hashFiles(format('implementations/{0}/**/*', matrix.impl), 'schemas/**/*', 'report.sh') }}-${{ inputs.runs || 3 }}
           lookup-only: ${{ matrix.skip_cache || startsWith(matrix.impl, 'blaze') || github.event_name == 'schedule' }}
+
+      - uses: actions/setup-go@v5
+      - name: Install gron
+        run: go install github.com/tomnomnom/gron@latest
 
       - name: Run benchmarks
         if: steps.cache-report.outputs.cache-hit != 'true'

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /dist
 /implementations/ajv/node_modules
 /implementations/boon/target/
+/schemas/*/schema-noformat.json
 /.DS_Store
 /node_modules
 .dockertimestamp

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ dist/results/plots/%.png: \
 	dist/results/plots \
 	dist/report.csv \
 	plot.py \
-	schemas/%/schema.json \
+	schemas/%/schema-noformat.json \
 	schemas/%/instances.jsonl
 	uv run python plot.py
 plots: $(ALL_PLOTS)
@@ -49,6 +49,9 @@ endef
 list:
 	@echo $(IMPLEMENTATIONS) | tr ' ' '\n'
 
+schemas/%/schema-noformat.json: schemas/%/schema.json
+	gron $< | grep -v 'format = "' | gron -u > $@
+
 # Blaze
 
 implementations/blaze/.dockertimestamp: \
@@ -60,7 +63,7 @@ implementations/blaze/.dockertimestamp: \
 
 dist/results/blaze/%: \
 	implementations/blaze/.dockertimestamp \
-	schemas/%/schema.json \
+	schemas/%/schema-noformat.json \
 	schemas/%/instances.jsonl \
 	| dist/results/blaze
 	@$(call docker_run,blaze,/workspace/$(dir $(word 2,$^)))
@@ -77,7 +80,7 @@ implementations/ajv/.dockertimestamp: \
 
 dist/results/ajv/%: \
 	implementations/ajv/.dockertimestamp \
-	schemas/%/schema.json \
+	schemas/%/schema-noformat.json \
 	schemas/%/instances.jsonl \
 	| dist/results/ajv
 	@$(call docker_run,ajv,/workspace/$(word 2,$^) /workspace/$(word 3,$^))
@@ -95,7 +98,7 @@ implementations/ajv-bun/.dockertimestamp: \
 
 dist/results/ajv-bun/%: \
 	implementations/ajv-bun/.dockertimestamp \
-	schemas/%/schema.json \
+	schemas/%/schema-noformat.json \
 	schemas/%/instances.jsonl \
 	| dist/results/ajv-bun
 	@$(call docker_run,ajv-bun,/workspace/$(word 2,$^) /workspace/$(word 3,$^))
@@ -111,7 +114,7 @@ implementations/boon/.dockertimestamp: \
 
 dist/results/boon/%: \
 	implementations/boon/.dockertimestamp \
-	schemas/%/schema.json \
+	schemas/%/schema-noformat.json \
 	schemas/%/instances.jsonl \
 	| dist/results/boon
 	@$(call docker_run,boon,/workspace/$(dir $(word 2,$^)))
@@ -128,7 +131,7 @@ implementations/json_schemer/.dockertimestamp: \
 
 dist/results/json_schemer/%: \
 	implementations/json_schemer/.dockertimestamp \
-	schemas/%/schema.json \
+	schemas/%/schema-noformat.json \
 	schemas/%/instances.jsonl \
 	| dist/results/json_schemer
 	@$(call docker_run,json_schemer,/workspace/$(dir $(word 3,$^)))
@@ -145,7 +148,7 @@ implementations/python-jsonschema/.dockertimestamp: \
 
 dist/results/python-jsonschema/%: \
 	implementations/python-jsonschema/.dockertimestamp \
-	schemas/%/schema.json \
+	schemas/%/schema-noformat.json \
 	schemas/%/instances.jsonl \
 	| dist/results/python-jsonschema
 	@$(call docker_run,python-jsonschema,/workspace/$(dir $(word 2,$^)))
@@ -162,7 +165,7 @@ implementations/go-jsonschema/.dockertimestamp: \
 
 dist/results/go-jsonschema/%: \
 	implementations/go-jsonschema/.dockertimestamp \
-	schemas/%/schema.json \
+	schemas/%/schema-noformat.json \
 	schemas/%/instances.jsonl \
 	| dist/results/go-jsonschema
 	@$(call docker_run,go-jsonschema,/workspace/$(dir $(word 2,$^)))
@@ -179,7 +182,7 @@ implementations/hyperjump/.dockertimestamp: \
 
 dist/results/hyperjump/%: \
 	implementations/hyperjump/.dockertimestamp \
-	schemas/%/schema.json \
+	schemas/%/schema-noformat.json \
 	schemas/%/instances.jsonl \
 	| dist/results/hyperjump
 	@$(call docker_run,hyperjump,/workspace/$(word 2,$^) /workspace/$(word 3,$^))
@@ -197,7 +200,7 @@ implementations/jsoncons/.dockertimestamp: \
 
 dist/results/jsoncons/%: \
 	implementations/jsoncons/.dockertimestamp \
-	schemas/%/schema.json \
+	schemas/%/schema-noformat.json \
 	schemas/%/instances.jsonl \
 	| dist/results/jsoncons
 	@$(call docker_run,jsoncons,/workspace/$(dir $(word 2,$^)))
@@ -214,7 +217,7 @@ implementations/corvus/.dockertimestamp: \
 
 dist/results/corvus/%: \
 	implementations/corvus/.dockertimestamp \
-	schemas/%/schema.json \
+	schemas/%/schema-noformat.json \
 	schemas/%/instances.jsonl \
 	| dist/results/corvus
 	@$(call docker_run,corvus,/workspace/$(word 2,$^) /workspace/$(word 3,$^))
@@ -231,7 +234,7 @@ implementations/schemasafe/.dockertimestamp: \
 
 dist/results/schemasafe/%: \
 	implementations/schemasafe/.dockertimestamp \
-	schemas/%/schema.json \
+	schemas/%/schema-noformat.json \
 	schemas/%/instances.jsonl \
 	| dist/results/schemasafe
 	@$(call docker_run,schemasafe,/workspace/$(word 2,$^) /workspace/$(word 3,$^))
@@ -247,7 +250,7 @@ implementations/jsonschemadotnet/.dockertimestamp: \
 
 dist/results/jsonschemadotnet/%: \
 	implementations/jsonschemadotnet/.dockertimestamp \
-	schemas/%/schema.json \
+	schemas/%/schema-noformat.json \
 	schemas/%/instances.jsonl \
 	| dist/results/jsonschemadotnet
 	@$(call docker_run,jsonschemadotnet,/workspace/$(word 2,$^) /workspace/$(word 3,$^))
@@ -266,7 +269,7 @@ implementations/kmp-json-schema-validator/.dockertimestamp: \
 
 dist/results/kmp-json-schema-validator/%: \
 	implementations/kmp-json-schema-validator/.dockertimestamp \
-	schemas/%/schema.json \
+	schemas/%/schema-noformat.json \
 	schemas/%/instances.jsonl \
 	| dist/results/kmp-json-schema-validator
 	@$(call docker_run,kmp-json-schema-validator,/workspace/$(word 2,$^) /workspace/$(word 3,$^))
@@ -274,7 +277,7 @@ dist/results/kmp-json-schema-validator/%: \
 # networknt
 
 implementations/networknt/.dockertimestamp: \
-	implementations/networknt/app/src/main/java/io/github/sourcemeta/App.java \
+	implementations/networknt/app/src/main/java/io/github/sourcemeta/*.java \
 	implementations/networknt/app/build.gradle.kts \
 	implementations/networknt/gradle/libs.versions.toml \
 	implementations/networknt/gradle/wrapper/gradle-wrapper.properties \
@@ -285,7 +288,7 @@ implementations/networknt/.dockertimestamp: \
 
 dist/results/networknt/%: \
 	implementations/networknt/.dockertimestamp \
-	schemas/%/schema.json \
+	schemas/%/schema-noformat.json \
 	schemas/%/instances.jsonl \
 	| dist/results/networknt
 	@$(call docker_run,networknt,/workspace/$(word 2,$^) /workspace/$(word 3,$^))

--- a/implementations/blaze/main.cc
+++ b/implementations/blaze/main.cc
@@ -27,7 +27,7 @@ bool validate_all(auto &evaluator, const auto &instances, const auto &schema_tem
 
 int validate(const std::filesystem::path &example) {
   const auto schema{
-      sourcemeta::jsontoolkit::from_file(example / "schema.json")};
+      sourcemeta::jsontoolkit::from_file(example / "schema-noformat.json")};
   auto stream{sourcemeta::jsontoolkit::read_file(example / "instances.jsonl")};
   std::vector<sourcemeta::jsontoolkit::JSON> instances;
   for (const auto &instance : sourcemeta::jsontoolkit::JSONL{stream}) {

--- a/implementations/boon/src/main.rs
+++ b/implementations/boon/src/main.rs
@@ -19,7 +19,7 @@ fn main() -> Result<(), Box<dyn Error>> {
   let example_folder = &args[1];
 
   // Get the schema and instance paths
-  let schema_file =   std::fs::canonicalize(example_folder.to_owned() + "/schema.json")?;
+  let schema_file =   std::fs::canonicalize(example_folder.to_owned() + "/schema-noformat.json")?;
   let instance_file = std::fs::canonicalize(example_folder.to_owned() + "/instances.jsonl")?;
 
   // Read the instance file

--- a/implementations/go-jsonschema/main.go
+++ b/implementations/go-jsonschema/main.go
@@ -34,7 +34,7 @@ func main() {
 	exampleFolder := os.Args[1]
 
 	// Construct and canonicalize file paths
-	schemaFile, err := filepath.Abs(filepath.Join(exampleFolder, "schema.json"))
+	schemaFile, err := filepath.Abs(filepath.Join(exampleFolder, "schema-noformat.json"))
 	if err != nil {
 		log.Fatalf("Error constructing schema file path: %v", err)
 	}

--- a/implementations/json_schemer/main.rb
+++ b/implementations/json_schemer/main.rb
@@ -14,7 +14,7 @@ end
 path = ARGV[0]
 
 # Load the schema and build a validator
-schema = JSON.parse(File.read(File.join(path, "schema.json")))
+schema = JSON.parse(File.read(File.join(path, "schema-noformat.json")))
 
 compile_start = Process.clock_gettime(Process::CLOCK_REALTIME, :nanosecond)
 schemer = JSONSchemer.schema(schema)

--- a/implementations/jsoncons/main.cc
+++ b/implementations/jsoncons/main.cc
@@ -21,7 +21,7 @@ void validate_all(const jsonschema::json_schema<Json> &compiled, const std::vect
 }
 
 int validate(const std::filesystem::path &example) {
-  std::ifstream input_schema((example / "schema.json").string());
+  std::ifstream input_schema((example / "schema-noformat.json").string());
   const auto schema = json::parse(input_schema);
 
   const auto compile_start{std::chrono::high_resolution_clock::now()};

--- a/implementations/python-jsonschema/validate.py
+++ b/implementations/python-jsonschema/validate.py
@@ -12,7 +12,7 @@ MAX_WARMUP_TIME = 1e9 * 10
 
 if __name__ == "__main__":
     example_dir = pathlib.Path(sys.argv[1])
-    schema = json.load(open(example_dir / "schema.json"))
+    schema = json.load(open(example_dir / "schema-noformat.json"))
     instances = [json.loads(doc) for doc in open(example_dir / "instances.jsonl").readlines()]
 
     Validator = jsonschema.validators.validator_for(schema)


### PR DESCRIPTION
Supporting "format" is optional in all the schemas we are considering.
Since Blaze does not implement "format", it would be unfair to compare
against other implementations that are performing check this
