### PR TITLE
Exclude content reading from the compilation time

### DIFF
--- a/implementations/kmp/app/src/main/kotlin/io/github/sourcemeta/App.kt
+++ b/implementations/kmp/app/src/main/kotlin/io/github/sourcemeta/App.kt
@@ -25,8 +25,9 @@ fun main(args: Array<String>) {
     val json = Json { ignoreUnknownKeys = true }
 
     // Prepare the schema
+    val schemaDefinition = File(args[0]).readText()
     val compileStart = System.nanoTime()
-    val schema = JsonSchema.fromDefinition(File(args[0]).readText())
+    val schema = JsonSchema.fromDefinition(schemaDefinition)
     val compileEnd = System.nanoTime()
 
     // Load all documents


### PR DESCRIPTION
Hi, I have noticed that most implementations do not include time to read the content from the file into schema compilation measurements. But this one does. Moved reading from file operation outside the measurement scope.

Also, I think it is worth re-checking the implementations to see if they all have similar conditions during measurements (e.g. kmp, networknt impls compile schema from a **string**, but json_schemer does it after the **string is parsed by JSON parser**).