### PR TITLE
Fix rebuild of Blaze Docker container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,8 @@ schemas/%/schema-noformat.json: schemas/%/schema.json
 
 # Blaze
 
+# Always try to build the Blaze image, let Docker cache things
+.PHONY: implementations/blaze/.dockertimestamp
 implementations/blaze/.dockertimestamp: \
 	implementations/blaze/CMakeLists.txt \
 	implementations/blaze/main.cc \

--- a/implementations/blaze/Dockerfile
+++ b/implementations/blaze/Dockerfile
@@ -8,6 +8,8 @@ RUN apk add --no-cache git build-base cmake
 COPY --exclude=./main.cc . /app
 RUN echo "int main(int argc, char**argv){}" > /app/main.cc
 
+# This serves to cache the following layers only if the commit has changed
+ADD "https://api.github.com/repos/sourcemeta/blaze/commits/${BLAZE_BRANCH}" /app/commit.json
 RUN git clone -b ${BLAZE_BRANCH} https://github.com/sourcemeta/blaze /app/repo
 RUN cmake -S /app -B /app/build -DCMAKE_BUILD_TYPE:STRING=Release -DBUILD_SHARED_LIBS:BOOL=OFF
 RUN cmake --build /app/build --config Release --parallel 4


### PR DESCRIPTION
This causes make to always rebuild the Blaze container.
Instead we rely on Docker caching to avoid unnecessary work.
