### PR TITLE
Use the `sourcemeta_enable_simd()` in Blaze

### DIFF
--- a/implementations/blaze/CMakeLists.txt
+++ b/implementations/blaze/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.16)
 project(blaze_benchmark)
 include(/app/repo/vendor/core/cmake/Sourcemeta.cmake)
+sourcemeta_enable_simd()
 set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3")
 set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -march=native")
 set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -mtune=native")


### PR DESCRIPTION
I'm making SIMD flags opt-in to make it easier to release cross-platform
binaries for tools like the JSON Schema CLI (as some target machines
will not support SIMD).

While we don't use SIMD directly, auto-vectorisation does, and saw
issues in the wild with the JSON Schema CLI binaries not working on
certain machines.

Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
