### PR TITLE
Add benchmarking with JSON Model Compiler and JSON Schema Utils

### DIFF
--- a/implementations/jmc/.gitignore
+++ b/implementations/jmc/.gitignore
@@ -1,0 +1,1 @@
+runs.txt

--- a/implementations/jmc/Dockerfile
+++ b/implementations/jmc/Dockerfile
@@ -1,0 +1,39 @@
+FROM ubuntu
+LABEL description="JSON Model Compiler Setup for Benchmarking"
+
+RUN apt update
+RUN apt upgrade -y
+
+# build & utils
+RUN apt install -y --no-install-recommends --fix-missing \
+        vim git ca-certificates libtool m4 time automake make pkgconf gcc g++ texinfo
+
+# libs and all
+RUN apt update
+RUN apt install -y --no-install-recommends --fix-missing \
+        libpcre2-dev libre2-dev libjansson-dev python3 python-is-python3 python3-venv python3-pip
+
+RUN apt clean
+
+# compile cre2 into /usr/local
+RUN git clone https://github.com/marcomaggi/cre2.git
+RUN cd cre2 ; \
+    sh autogen.sh ; \
+    ./configure --enable-maintainer-mode ; \
+    make ; \
+    make install
+
+# setup python environment
+RUN python -m venv /venv
+RUN /venv/bin/pip install -U pip
+
+# direct install json-model and json-schema-utils from github
+RUN echo 33
+RUN git clone https://github.com/clairey-zx81/json-model.git
+RUN git clone https://github.com/zx80/json-schema-utils.git
+RUN /venv/bin/pip install -e ./json-model ./json-schema-utils
+
+# setup benchmarking scripts
+COPY . /app
+ENV LD_LIBRARY_PATH=/usr/local/lib
+ENTRYPOINT ["/app/memory-wrapper.sh", "/app/generate-and-run.sh"]

--- a/implementations/jmc/Makefile
+++ b/implementations/jmc/Makefile
@@ -1,0 +1,53 @@
+SHELL   = /bin/bash
+.ONESHELL:
+
+.PHONY: build
+build: memory-wrapper.sh
+	docker build -t jmc -f Dockerfile .
+
+memory-wrapper.sh: ../../memory-wrapper.sh
+	cp $< $@
+
+.PHONY: clean
+clean:
+	docker image prune -f
+	$(RM) memory-wrapper.sh runs.txt
+
+.PHONY: clean.docker
+clean.docker:
+	docker container prune -f
+	docker image rm -f $$(docker image ls | grep '^<none>' | tr -s " " " " | cut -d' ' -f 3) jmc
+
+# FIXME stop containers?
+# run one bench
+BENCH   = babelrc
+
+.PHONY: run
+run: build
+	docker run -v ../../schemas:/schemas jmc \
+	    /schemas/$(BENCH)/schema.json /schemas/$(BENCH)/instances.jsonl
+
+# run all benches
+BENCHES = $(basename $(dir $(wildcard ../../schemas/*/schema.json)))
+
+.PHONY: runs
+runs: build
+	for bench in $(BENCHES) ; do
+	    echo "# considering $$bench"
+	    docker run -v ../../schemas:/schemas jmc \
+	        /schemas/$$bench/schema.json /schemas/$$bench/instances.jsonl
+	done
+
+runs.txt: Dockerfile generate-and-run.sh memory-wrapper.sh
+	$(MAKE) runs > $@ 2>&1
+
+.PHONY: version
+version: build
+	docker run --entrypoint /app/version.sh jmc
+
+.PHONY: status
+status:
+	# docker volume ls
+	docker container ls -a
+	docker image ls -a
+

--- a/implementations/jmc/README.md
+++ b/implementations/jmc/README.md
@@ -1,0 +1,108 @@
+# Benchmark runs with JSON Model Compiler
+
+JMC is **not** a JSON Schema implementation per se, but implements code generation
+for JSON Model which aims at validating JSON data structures.
+This benchmark uses json-schema-utils proof-of-concept JSON schema to JSON model
+converter to generate models.
+
+## Schema to Model Conversion
+
+The conversion occurs in three phases:
+
+1. the schema is first simplified, especially wrt reference management
+2. then if it has a corresponding _official_ model, use it (based on `$id`)
+3. otherwise, generate a model in _loose_ mode (which accept any bug-looking oddity)
+
+The automatic translation is not strictly faithfull to schema semantics due to corner case
+differences, attempts to fix schema issues (eg typical cases of misplaced keywords
+are fixed to reflect the designer intention, which may lead to invalid data reported
+from this benchmark point of view) and that it is designed to convert draft-2020-12 schemas,
+whereas this benchmark mostly contains older draft-07 schemas.
+
+## Model Compilation
+
+Compilation builds an executable from generated C code mostly with `re2` as a regular
+expression engine, with loose numbers.
+
+The compilation time reported includes converting the schema to a model,
+generating C source code from the model, and compiling the C code and the (small)
+support library to an executable.
+
+## Benchmarking
+
+Benchmarking time is an average over 100 validations of all tests values after
+loading them into memory.
+
+Exit status is 0 if all JSON values were validated, 1 otherwise.
+
+## Status
+
+- [x] ansible-meta pass=330 fail=3 error=0
+  - 105: `dependecies` prop typo because of fixed `additionalProperties`
+  - 201: `argument_specs` prop because of fixed `additionalProperties`
+  - 105: `argument_specs` prop because of fixed `additionalProperties`
+- [x] aws-cdk pass=483 fail=0 error=0
+- [x] babelrc pass=794 fail=0 error=0
+- [x] clang-format pass=133 fail=0 error=0
+- [x] cmake-presets pass=967 fail=0 error=0
+- [x] code-climate pass=2484 fail=0 error=0
+- [x] cql2 pass=109 fail=0 error=0
+- [x] cspell **pcre2** pass=981 fail=0 error=0
+  - 2 regular expressions uselessly re extensions incompatible with re2
+- [x] cypress pass=981 fail=0 error=0
+- [x] deno pass=987 fail=0 error=0
+- [x] dependabot pass=967 fail=0 error=0
+- [x] draft-04 pass=563 fail=0 error=0
+- [x] fabric-mod pass=911 fail=0 error=0
+- [x] geojson pass=500 fail=0 error=0
+- [x] gitpod-configuration pass=986 fail=0 error=0
+- [x] helm-chart-lock pass=3888 fail=0 error=0
+- [x] importmap pass=964 fail=0 error=0
+- [x] jasmine pass=980 fail=0 error=0
+- [x] jsconfig pass=981 fail=0 error=0
+- [x] jshintrc pass=966 fail=0 error=0
+- [x] krakend pass=47 fail=0 error=0
+- [x] lazygit pass=279 fail=1 error=0
+  - 47-c: obscure issue with utf8 string length, `bmstowcs` returns _-1_
+- [x] lerna pass=985 fail=0 error=0
+- [x] nest-cli pass=1025 fail=0 error=0
+- [x] omnisharp pass=987 fail=0 error=0
+- [x] openapi pass=106 fail=1 error=0
+  - 26: `"<local-terminal-IP-address>"` is not really a valid URI reference
+  - NOTE: beware that the provided schema does _not_ validate schemas…
+- [x] pre-commit-hooks pass=985 fail=0 error=0
+- [x] pulumi pass=3807 fail=0 error=0
+- [x] semantic-release pass=794 fail=0 error=0
+- [x] stale pass=961 fail=0 error=0
+- [x] stylecop pass=983 fail=0 error=0
+- [x] tmuxinator pass=382 fail=0 error=0
+- [x] ui5 pass=942 fail=0 error=0
+- [x] ui5-manifest **pcre2** pass=611 fail=0 error=0
+  - one regular expressions extension incompatible with re2
+- [x] unreal-engine-uproject pass=859 fail=0 error=0
+- [x] vercel pass=710 fail=0 error=0
+- [x] yamllint pass=966 fail=18 error=0
+  - the 18 differences are raw strings, model conversion rightfully infer object requirement
+    thus reject strings like "hello world" as valid yamllint values
+
+## Make Commands
+
+```sh
+make BENCH=lerna run  # run for one benchmark directory
+make runs.txt         # run for all benchmark directories, with results in runs.txt
+make clean            # local and docker cleanup
+make version          # show jmc versions
+```
+
+## TODO
+
+- add python benchmarking
+- add js benchmarking
+
+## Docker Commands
+
+```sh
+docker build -t jmc -f Dockerfile .
+docker run -it --entrypoint /bin/bash jmc
+docker run -v ../../schemas:/schemas jmc ...
+```

--- a/implementations/jmc/generate-and-run.sh
+++ b/implementations/jmc/generate-and-run.sh
@@ -1,0 +1,89 @@
+#! /bin/bash
+
+SCHEMA=$1
+INSTANCES=$2
+
+LOOP=100
+NAME=$(basename $(dirname $SCHEMA))
+
+function H
+{
+    echo "# $NAME" "$@" >&2
+}
+
+
+#
+# SPECIAL CASE HANDLING
+#
+case $NAME in
+    cspell|ui5-manifest)
+        H uselessly re2 incompatible regex
+        jmc_opt="-re pcre2"
+        jsu_model_opt=
+        ;;
+    openapi)
+        jmc_opt=
+        jsu_model_opt="--no-id"
+        ;;
+    *)
+        jmc_opt=
+        jsu_model_opt=
+        ;;
+esac
+
+source /venv/bin/activate
+rm -f model.json model.out
+
+#
+# COMPILE
+#
+
+let compile_start=$(date +%s.%N | tr -d .)
+
+H generating...
+# generate model from schema, by id or strict conversion
+jsu-simpler "$SCHEMA" | jsu-model --id --loose $jsu_model_opt > model.json
+status=$?
+
+if [ $status -eq 0 ] ; then
+    # generate exec from model
+    H compiling...
+    jmc --loose-number --maps "https://json-model.org/models/ /json-model/models/" \
+        $jmc_opt -o ./model.out model.json
+    status=$?
+fi
+
+let compile_end=$(date +%s.%N | tr -d .)
+let compile_time=$(( $compile_end - $compile_start))
+
+H compile time: $(( $compile_time / 1000 )) µs
+[ $status -ne 0 ] && exit $status
+
+#
+# BENCH
+#
+H benchmarking...
+
+let run_start=$(date +%s.%N | tr -d .)
+./model.out --jsonl "$INSTANCES" > model.txt
+status=$?
+let run_end=$(date +%s.%N | tr -d .)
+let run_time=$(( $run_end - $run_start))
+
+H run time: $(( $run_time / 1000 )) µs
+
+# run again with internally measured time
+./model.out --jsonschema-benchmark -T $LOOP "$INSTANCES" > time.txt
+let valid_time=$(cat time.txt)
+
+H valid time: $valid_time µs
+
+# summary
+pass=$(grep PASS model.txt | wc -l)
+fail=$(grep FAIL model.txt | wc -l)
+err=$(grep ERROR model.txt | wc -l)
+H pass=$pass fail=$fail error=$err
+
+# timing & exit
+echo $valid_time,$compile_time
+exit $status

--- a/implementations/jmc/version.sh
+++ b/implementations/jmc/version.sh
@@ -1,0 +1,16 @@
+#! /bin/bash
+
+function git_version()
+{
+  local dir=$1
+  pushd $dir > /dev/null
+  git log -1 | head -1 | cut -d' ' -f2 | cut -c -8
+}
+
+jmc_ver=$(/venv/bin/jmc --version)
+jmc_git=$(git_version /json-model)
+jsu_ver=$(/venv/bin/jsu-model --version)
+jsu_git=$(git_version /json-schema-utils)
+cc_ver=$(cc --version | head -1)
+
+echo "jmc=$jmc_ver-$jmc_git jsu=$jsu_ver-$jsu_git cc=$cc_ver"


### PR DESCRIPTION
This is a preliminary setup to add [jmc](https://github.com/clairey-zx81/json-model) as an implementation.

- I'm not really sure whether this is enough to run with your benchmarking stuff.
- There are a few diffs, most of which should be resolved by fixing the schemas or the validated instances.
- Overall, I think that the benchmarking runs are too short.