### PR TITLE
skip jsv

### DIFF
--- a/.github/list-implementations.sh
+++ b/.github/list-implementations.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
 # Get a list of all implementations (with some potentially ignored)
-# XXX Temporarily exclude Corvus
-all_impls=$(make NO_IGNORE=$NO_IGNORE list | grep -v corvus |sort)
+# XXX Temporarily exclude Corvus and JSV
+all_impls=$(make NO_IGNORE=$NO_IGNORE list | grep -v corvus | grep -v "^jsv$" | sort)
 
-# Add implementations changed in the PR
+# Add implementations changed in the PR (but avoid .benchmark-ignore)
 if [ "$GITHUB_EVENT_NAME" == "pull_request" ]; then
   git fetch origin $GITHUB_BASE_REF --depth 1
-  pr_impls=$(git diff --name-only FETCH_HEAD..HEAD | grep '^implementations/' | cut -d/ -f2 | sort -u)
+  pr_impls=$(git diff --name-only FETCH_HEAD..HEAD | grep '^implementations/' | grep -v '/.benchmark-ignore' | cut -d/ -f2 | sort -u)
 fi
 
 # Get all implementations that are modified by the PR

--- a/implementations/jsv/.benchmark-ignore
+++ b/implementations/jsv/.benchmark-ignore
@@ -1,0 +1,8 @@
+Docker build broken on a certifacate issue since June 11th, 2026.
+The Let's Encrypt certificate for `builds.hex.pm` was updated on this date.
+
+```
+#10 0.770 ** (Mix) httpc request failed with: {:failed_connect, [{:to_address, {~c"builds.hex.pm", 443}}, {:inet, [:inet], {:tls_alert, {:unsupported_certificate, ~c"TLS client: In state wait_cert_cr at ssl_handshake.erl:2199 generated CLIENT ALERT: Fatal - Unsupported Certificate\n {key_usage_mismatch,{{'Extension',{2,5,29,15},true,[keyCertSign,cRLSign]},\n                      {'Extension',{2,5,29,37},false,[{1,3,6,1,5,5,7,3,1}]}}}"}}}]}
+1
+#10 0.770 Could not install Hex because Mix could not download metadata at https://builds.hex.pm/installs/hex-1.x.csv.
+```


### PR DESCRIPTION
The benchmark has been broken for over month on jsv docker build because of a certificate issue in the erlang ecosystem.

Maybe the benchmarking process could be made more resilient on occasional build failures?